### PR TITLE
Clarify in the docs which object is the considered the "old" vs "new".

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -3,7 +3,7 @@
 [objectdiff on npm](http://search.npmjs.org/#/objectdiff)
 
 
-## objectDiff.diff(objectA, objectB)
+## objectDiff.diff(oldObject, newObject)
 
 <pre>
 objectDiff.diff({x: 1}, {x: 2})
@@ -40,7 +40,7 @@ objectDiff.diff({z: {x: 1}}, {z: {y: 2}})
 </pre>
 
 
-## objectDiff.diffOwnProperties(objectA, objectB)
+## objectDiff.diffOwnProperties(oldObject, newObject)
 
 Same as objectDiff.diff, but compares only objects' own properties
 


### PR DESCRIPTION
Some diff'ing functions, particularly for testing use the sematics of `diff(actual,expected)`. You see this for example in the `unfunk-diff` library uses this library. 

Other tools like this one use the sematics of `diff(old,new)`. Either can make sense, but it's not clear which semantics are being used when the example arguments are 'ObjectA' and 'ObjectB'.   

Updating the example input names clarify which semantics are being used here.
